### PR TITLE
Added additional grouping for regex filtering

### DIFF
--- a/src/ConfigHandler.js
+++ b/src/ConfigHandler.js
@@ -86,6 +86,11 @@ export default class {
                 }
             });
             d['directory_users']['groups'] = groups;
+            // Initializes additional_groups in yaml file since on install it does not exist
+            let additional_groups = d['directory_users']['additional_groups']
+            if (!additional_groups) {
+                d['directory_users']['additional_groups'] = [];
+            }
 
             if(callback){
                 callback(d, false);

--- a/src/USTConfig.js
+++ b/src/USTConfig.js
@@ -22,7 +22,9 @@ export default class extends React.Component {
         this.state = {
             isonerror: false,
             alertmsg: "", 
-            editmapidx: -1
+            editmapidx: -1,
+            editdynamicmapidx: -1,
+            showDynamicMapping: false
         }
     }
 
@@ -137,6 +139,72 @@ export default class extends React.Component {
 
     handleAddGroup = (idx) => (e) => {
         e.preventDefault();        
+    }
+
+    // This function toggles showing or hiding the dynamic mapping inputs
+    showAdvancedGrouping = (e) => {
+        e.preventDefault();
+        this.setState({
+            showDynamicMapping: !this.state.showDynamicMapping
+        });
+    }
+
+    // This function show the inputs when the user clicks add pattern also puts the inputs in the correct descending order
+    handleAddDynamicMapping = (e) => {
+        const cd = this.props.configData;
+        const s = this.state;
+        if(s.editdynamicmapidx === -1) {
+            const mp = { 
+                source: "", 
+                target: ""
+            };
+
+            cd.directory_users.additional_groups.push(mp);            
+            this.setState(prevState => ({
+                editdynamicmapidx: cd.directory_users.additional_groups.length-1
+            }));
+        }
+    }
+
+    // This function handles the inputs for target and source and then adds them to the config data state
+    handleDynamicChangeMap = (elname, idx) => (e) => {
+        e.preventDefault();
+        const cd = this.props.configData;
+        const mp = cd.directory_users.additional_groups[this.state.editdynamicmapidx];
+        if (elname === "MAP.source") {
+            mp.source = e.target.value;
+            this.setState({});
+        }
+        else if (elname === "MAP.target") {
+            mp.target = e.target.value;
+            this.setState({});
+        }
+    }
+
+    // This function handles the switch from input view back to list view
+    handleSaveDynamicMapping = (e) => {
+        e.preventDefault();
+        this.setState({
+            editdynamicmapidx: -1
+        });
+    }
+
+    // This function handles the switch from list view to input view to allow the user to edit their dynamic groupings
+    handleEditDynamicMapping = (idx) => (e) => {
+        e.preventDefault();
+        this.setState({
+            editdynamicmapidx: idx
+        });
+    }
+
+    // This function handles the removing of dynamic grouping by using the splice function and removes them from configData object
+    handleRemoveDynamicMapping = (idx) => (e) => {
+        e.preventDefault();
+        const cd = this.props.configData;
+        cd.directory_users.additional_groups.splice(idx, 1);
+        this.setState({
+            editdynamicmapidx: -1
+        });
     }
     
     render() {
@@ -268,6 +336,103 @@ export default class extends React.Component {
                     </FormGroup>
                 </div>
                 <div className="row form-group">
+                    <div>
+                        <legend>Dynamic Grouping <small>(optional)</small>{!s.showDynamicMapping ?
+                            <a href="#" style={{ marginTop: 5, marginLeft: 5, verticalAlign: "top" }} onClick={this.showAdvancedGrouping}>Create</a> :
+                            <a href="#" style={{ marginTop: 5, marginLeft: 5, verticalAlign: "top" }} onClick={this.showAdvancedGrouping}>Hide</a>
+                        }</legend>
+                    </div>
+                    {s.showDynamicMapping ?
+                        <FormGroup className="col-sm-12">
+                            <ListGroup>
+                                <div className="container" style={{ padding: 0, margin: 0 }}>
+                                    <div className="row">
+                                        <div className="col-sm-5">
+                                            <Label>Source</Label>
+                                        </div>
+                                        <div className="col-sm-7">
+                                            <Label style={{ marginLeft: 16 }}>Target</Label>
+                                        </div>
+                                    </div>
+                                    {
+                                        cd.directory_users.additional_groups.length === 0 ?
+                                            <ListGroupItem className="justify-content-between">
+                                                <div className="row">
+                                                    <div className="col-sm-12">
+                                                        <span style={{ color: "gray", fontSize: "0.75rem" }}>No Dynamic Groupings found. Click 'Add New Pattern'.</span>
+                                                    </div>
+                                                </div>
+                                            </ListGroupItem> :
+                                            cd.directory_users.additional_groups.map((mp, idx) =>
+                                                s.editdynamicmapidx === idx ?
+                                                    <ListGroupItem key={idx} className="justify-content-between" color="warning">
+                                                        <div className="row">
+                                                            <div className="col-sm-5">
+                                                                <input
+                                                                    style={{ borderRadius: 0, marginLeft: -3 }}
+                                                                    type="text"
+                                                                    placeholder="acl-(.+)"
+                                                                    value={mp.source}
+                                                                    onChange={this.handleDynamicChangeMap('MAP.source')}
+                                                                />
+                                                            </div>
+                                                            <div className="col-sm-6">
+                                                                <div>
+                                                                    <span style={{ marginRight: 10 }}><i className="fa fa-arrow-right"></i></span>
+                                                                    <span>
+                                                                        <input
+                                                                            style={{ borderRadius: 0 }}
+                                                                            type="text"
+                                                                            placeholder="aem-(\1)"
+                                                                            value={mp.target}
+                                                                            onChange={this.handleDynamicChangeMap('MAP.target')}
+                                                                        />
+                                                                    </span>
+                                                                </div>
+                                                            </div>
+                                                            <div className="col-sm-1 text-right">
+                                                                <a href="#" onClick={this.handleSaveDynamicMapping}>
+                                                                    <i className="fa fa-floppy-o"></i>
+                                                                </a>
+                                                            </div>
+                                                        </div>
+                                                    </ListGroupItem> :
+                                                    <ListGroupItem key={idx} className="justify-content-between">
+                                                        <div className="row">
+                                                            <div className="col-sm-5">
+                                                                {mp.source}
+                                                            </div>
+                                                            <div className="col-sm-6">
+                                                                <span style={{ marginRight: 10 }}><i className="fa fa-arrow-right"></i></span>
+                                                                <span>{mp.target}</span>
+                                                            </div>
+                                                            <div className="col-sm-1 text-right">
+                                                                <UncontrolledDropdown size="sm">
+                                                                    <DropdownToggle tag="a" href="#">
+                                                                        <i className="fa fa-ellipsis-h"></i>
+                                                                    </DropdownToggle>
+                                                                    <DropdownMenu style={{ fontSize: "0.85rem" }}>
+                                                                        <DropdownItem onClick={this.handleEditDynamicMapping(idx)}>
+                                                                            <i className="fa fa-pencil-square-o" style={{ height: 16, marginTop: 1 }}></i>&nbsp;Edit
+                                                                        </DropdownItem>
+                                                                        <DropdownItem onClick={this.handleRemoveDynamicMapping(idx)}>
+                                                                            <i className="fa fa-trash-o" style={{ height: 16 }}></i>&nbsp;Delete
+                                                                        </DropdownItem>
+                                                                    </DropdownMenu>
+                                                                </UncontrolledDropdown>
+                                                            </div>
+                                                        </div>
+                                                    </ListGroupItem>
+                                            )
+                                    }
+                                </div>
+                            </ListGroup>
+                            <a href="#" style={{ marginTop: 5, marginLeft: 5 }} onClick={this.handleAddDynamicMapping}><i className="fa fa-plus-circle"></i>&nbsp;Add New Pattern</a>
+                        </FormGroup> :
+                        null
+                    }
+                </div>
+                <div className="row form-group">
                     <legend>Advanced <small className="text-muted">limits, logging, exclude users</small></legend>
                     <FormGroup className="col-sm-6">
                         <Label>Limit</Label>
@@ -301,5 +466,6 @@ export default class extends React.Component {
 
     componentDidMount() {
         this.showHelp("Sync settings of user groups mappings and other information");
+        this.setState({showDynamicMapping: this.props.configData.directory_users.additional_groups.length >= 1})
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added additional grouping feature to allow users to be able to filter directory groups based on REGEX input. This is a quality of life improvement for clients with organizations that have many groups with similar names so that they do not need to add them one by one. The changes made to the project include changes to:
ConfigHandler.js:
- Added additional_groups sub-object in the loadConfigFile function to initialize additional_groups so that it can be written to the user sync config file on save and will then be accessible from the USTConfig.js component.

USTConfig.js:
- Added new editdynamicmapidx state property that is used to change the view from a list of groups to either editing or adding new. It is also used to determine which grouping the user is editing or deleting by setting the index to whatever index the user selects.
- Added new showDynamicMapping boolean state property that shows or hides the additional/Dynamic Grouping view based on the user's selection or if additional_groups already contains mappings.
- Added showAdvancedGrouping function that fires whenever the user clicks the create link to show the additional/Dynamic grouping options or hides them if they click the hide link.
- Added handleDynamicMapping function that shows inputs when the user clicks the add pattern link and also puts the inputs in the correct descending order and add source and target mapping to configData object.
- Added handleDynamicChangeMap function that gets passed an element name which could be either MAP.Source or MAP.Target depending on which input the user is currently using. Depending on the input the value of the input is then added to the configData object.
- Added handleSaveDynamicMapping function that handles the switch from input view back to list view
- Added handleEditDynamicMapping function that is passed the index of the grouping the user is editing and then sets editdynamicmapidx to that index which in turn then shows the user the inputs for the grouping they are editing.
- Added handleRemoveDynamicMapping function that is passed the index of the grouping the user would like to remove and then uses that index to then splice the object which then removes that grouping.
- Created a new JSX container to hold dynamic grouping mappings and inputs. This can be shown or hidden by clicking create or hide.
 
<!--- Describe your changes in detail -->

## Related Issue
Story 182 - https://jira.corp.adobe.com/browse/DMESVCS-182
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This feature allows the user to take advantage of the UST's regex filter in order to search their active directory groups for groups with certain group names or prefixes using regex.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/64909135/82491280-0e1b2800-9aaa-11ea-9cbc-6b7b0d0af36b.png)
![image](https://user-images.githubusercontent.com/64909135/82491341-25f2ac00-9aaa-11ea-819a-c6c86747396b.png)
![image](https://user-images.githubusercontent.com/64909135/82491419-3c990300-9aaa-11ea-8bef-58a5cbd819c8.png)
![image](https://user-images.githubusercontent.com/64909135/82491465-4cb0e280-9aaa-11ea-8295-3dc51da2226a.png)
![image](https://user-images.githubusercontent.com/64909135/82491540-60f4df80-9aaa-11ea-82d8-b55b5bcfd295.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.